### PR TITLE
adds overloads to aggregator::determineTimestamp

### DIFF
--- a/objectDetectionTypes.hpp
+++ b/objectDetectionTypes.hpp
@@ -7,6 +7,7 @@
 #include <base/Time.hpp>
 // TODO 1 #include <mars/interfaces/snmesh.h>
 
+
 namespace mars
 {
 
@@ -68,4 +69,30 @@ namespace mars
   };
 
 }
+
+// need to tell the stream_aligner/transformer that the timestamp of these types
+// is hidden in "header.stamp", instead of the default "time" member variable
+namespace aggregator {
+    inline base::Time determineTimestamp(const mars::Detection3DArray& sample)
+    {
+        return sample.header.stamp;
+    }
+
+    inline base::Time determineTimestamp(const mars::Detection3D& sample)
+    {
+        return sample.header.stamp;
+    }
+
+    inline base::Time determineTimestamp(const mars::PointCloud& sample)
+    {
+        return sample.header.stamp;
+    }
+
+    inline base::Time determineTimestamp(const mars::Header& sample)
+    {
+        return sample.stamp;
+    }
+}
+
+
 #endif


### PR DESCRIPTION
For the stream aligner and transformer to work, access to a timestamp in
the message is needed. By default a member variable called "time" is
assumed to exist, which is not the case in the objectDetectionMessages.
Therefore, overloads to determineTimestamp are provided which correctly
access the timestamp in the header of the messages.